### PR TITLE
비디오 태그에 playsinline 속성 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
                 </div>
 
                 <div class="video">
-                    <video src="./assets/videos/exaple-video.mp4" class="video__player" autoplay loop muted
+                    <video src="./assets/videos/exaple-video.mp4" class="video__player" autoplay loop muted playsinline
                         preload="metadata"></video>
                     <div class="video__content-wrapper">
                         <div class="video__content">


### PR DESCRIPTION
모바일에서 비디오가 비디오가 전체 화면으로 열리는 문제가 발생하여 비디오 태그에 playsinline 속성을 추가하여 문제 해결